### PR TITLE
Update to handle namespaced message reporting defines

### DIFF
--- a/src/api/Compiler.hx
+++ b/src/api/Compiler.hx
@@ -374,9 +374,13 @@ class Compiler {
 			throw '$program';
 		}
 
-		var args = [
-			"-main", program.mainClass, "-cp", ".", "--times", "-D", "macro-times", "-D", "message-reporting=pretty", "-D", "no-color",
-		];
+		var args = ["-main", program.mainClass, "-cp", ".", "--times", "-D", "macro-times",];
+
+		if (program.haxeVersion == Haxe_4_3_0)
+			args = args.concat(["-D", "message-reporting=pretty", "-D", "no-color"]);
+		else
+			args = args.concat(["-D", "message.reporting=pretty", "-D", "message.no-color"]);
+
 		if (!program.haxeVersion.startsWith("2")) {
 			args.push("-dce");
 			args.push(program.dce);

--- a/src/api/Program.hx
+++ b/src/api/Program.hx
@@ -52,6 +52,7 @@ enum ECMAScriptVersion {
 	// var Haxe_3_3_0_rc_1 = "3.3.0-rc.1";
 	// var Haxe_3_2_1 = "3.2.1";
 	var Haxe_4_1_5 = "4.1.5";
+	var Haxe_4_3_0 = "4.3.0";
 }
 
 typedef Output = {


### PR DESCRIPTION
This will fix pretty errors for 4.3.1 and for nightlies starting now.
See https://github.com/HaxeFoundation/haxe/pull/11142 / https://github.com/HaxeFoundation/haxe/commit/5589eba7cbaa18234e98ffcbf33a32df9aa9e414

We should wait for either 4.3.1 release (early next week I assume) or full list of available nightlies being updated to `5.0.0-alpha.1` (would be nice to have that before 4.3.1 release but with CI being mostly broken it might take a while...)