### PR TITLE
Add support for cppia target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: ['js', 'neko', 'interp', 'hl']
+        target: ['js', 'neko', 'interp', 'hl', 'cppia']
         haxe-version: [3.4.7, 4.2.5, latest]
         exclude:
           - haxe-version: 3.4.7

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lixSetup/haxe/haxe_libraries
 lixSetup/haxe/neko
 lixSetup/haxe/versions/**
 lixSetup/*.img
+cppia-bin/**
 hashlink-bin/**
 tests/RunCi.n
 tests/bin

--- a/cppia-bin/Dockerfile
+++ b/cppia-bin/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:jammy
+RUN export DEBIAN_FRONTEND=noninteractive
+RUN ln -fs /usr/share/zoneinfo/Europe/Kiev /etc/localtime
+WORKDIR /srv/program
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates build-essential gcc g++ git nodejs npm
+RUN npm i lix --global
+RUN lix scope create --global
+RUN lix install --global haxe 4.3.7
+RUN haxelib setup /root/haxe/haxelib
+CMD rm -rf hxcpp; \
+    git clone https://github.com/HaxeFoundation/hxcpp.git --depth=1 --single-branch; \
+	haxelib dev hxcpp hxcpp; \
+	haxe -C hxcpp/tools/hxcpp compile.hxml; \
+    haxe -C hxcpp/project compile-cppia.hxml;  \
+    cp hxcpp/bin/Linux64/Cppia /cppia-bin/

--- a/docker-compose-all.yml
+++ b/docker-compose-all.yml
@@ -27,6 +27,7 @@ services:
     container_name: try-haxe_compiler
     build: ./compilation
     volumes:
+      - ./cppia-bin:/opt/cppia:ro
       - ./hashlink-bin:/opt/hashlink:ro
       - ./lixSetup/haxe:/home/haxer/haxe:ro
       - ./tmp:/home/haxer/programs
@@ -35,6 +36,11 @@ services:
     cpus: 6
     mem_limit: 20gb
     mem_reservation: 8gb
+  cppia.exe:
+    build: ./cppia-bin
+    image: try-haxe_cppia.exe
+    volumes:
+      - ./cppia-bin:/cppia-bin
   hl.exe:
     build: ./hashlink-bin
     image: try-haxe_hl.exe

--- a/src/Editor.hx
+++ b/src/Editor.hx
@@ -489,6 +489,8 @@ class Editor {
 				api.Program.TargetV2.HL('test');
 			case "EVAL":
 				api.Program.TargetV2.EVAL('test');
+			case "CPPIA":
+				api.Program.TargetV2.CPPIA('test');
 			case _:
 				api.Program.TargetV2.JS('test', selectedJsVersion);
 		}
@@ -520,7 +522,7 @@ class Editor {
 				jsVersion.fadeIn();
 			// jsTab.fadeIn();
 
-			case NEKO(_) | HL(_) | EVAL(_):
+			case NEKO(_) | HL(_) | EVAL(_) | CPPIA(_):
 				jsVersion.hide();
 				jsTab.hide();
 		}

--- a/src/Editor.hx
+++ b/src/Editor.hx
@@ -543,7 +543,7 @@ class Editor {
 	}
 
 	function initLibs() {
-		for (t in Type.getEnumConstructs(api.Program.Target)) {
+		for (t in Type.getEnumConstructs(api.Program.TargetV2)) {
 			var el = libs.find("." + t + "-libs");
 			var libs:Array<Libs.LibConf> = Libs.getLibsConfig(t);
 			var def:Array<String> = Libs.getDefaultLibs(t);

--- a/src/Libs.hx
+++ b/src/Libs.hx
@@ -86,9 +86,27 @@ class Libs {
 			{name: "tink_macro", help: "https://github.com/haxetink/tink_macro"},
 			{name: "utest", help: "https://github.com/haxe-utest/utest"},
 		],
+		"CPPIA" => [
+			{name: "actuate", help: "https://github.com/openfl/actuate", args: []},
+			{name: "format", help: "https://github.com/HaxeFoundation/format"},
+			{name: "hx3compat", help: "https://github.com/HaxeFoundation/hx3compat"},
+			{
+				name: "hxColorToolkit",
+				help: "https://github.com/andyli/hxColorToolkit"
+			},
+			{name: "hxmath", help: "https://github.com/tbrosman/hxmath", args: []},
+			{name: "pecan", help: "https://github.com/Aurel300/pecan"},
+			{name: "thx.core", help: "https://github.com/fponticelli/thx.core"},
+			{name: "thx.culture", help: "https://github.com/fponticelli/thx.culture"},
+			{name: "tink_core", help: "https://github.com/haxetink/tink_core"},
+			{name: "tink_lang", help: "https://github.com/haxetink/tink_lang"},
+			{name: "tink_macro", help: "https://github.com/haxetink/tink_macro"},
+			{name: "safety", help: "https://github.com/RealyUniqueName/Safety"},
+			{name: "utest", help: "https://github.com/haxe-utest/utest"},
+		],
 	];
 
-	static var defaultChecked:Map<String, Array<String>> = ["JS" => [], "NEKO" => [], "EVAL" => [], "HL" => []]; // array of lib names
+	static var defaultChecked:Map<String, Array<String>> = ["JS" => [], "NEKO" => [], "EVAL" => [], "HL" => [], "CPPIA" => []]; // array of lib names
 
 	static public function getLibsConfig(?target:TargetV2, ?targetName:String):Array<LibConf> {
 		var name = targetName != null ? targetName : Type.enumConstructor(target);

--- a/src/api/Compiler.hx
+++ b/src/api/Compiler.hx
@@ -296,6 +296,10 @@ class Compiler {
 				args.push("-hl");
 				args.push("dummy.hl");
 
+			case CPPIA(_):
+				args.push("-cppia");
+				args.push("dummy.cppia");
+
 			case EVAL(_):
 		}
 
@@ -478,6 +482,12 @@ class Compiler {
 				outputPath = "";
 				args.push("--run");
 				args.push(program.mainClass);
+
+			case CPPIA(name):
+				Api.checkSanity(name);
+				outputPath = "run.cppia";
+				args.push("-cppia");
+				args.push(outputPath);
 		}
 
 		var out = runHaxeDocker(program, args);
@@ -523,7 +533,7 @@ class Compiler {
 				case JS(_):
 					output.source = File.getContent(outputPath);
 					html.body.push("<script>" + output.source.replace("</script", "&lt;/script") + "</script>");
-				case NEKO(_) | HL(_) | EVAL(_):
+				case NEKO(_) | HL(_) | EVAL(_) | CPPIA(_):
 					html.body.push("<div style='overflow:auto; height:100%; width: 100%;'><pre>" + out.out.htmlEscape(true) + "</pre></div>");
 				default:
 			}
@@ -583,6 +593,8 @@ class Compiler {
 				docker += ' && timeout 1s neko run.n > raw_out 2> raw_err';
 			case HL(_):
 				docker += ' && LD_LIBRARY_PATH="/opt/hashlink:$$LD_LIBRARY_PATH" timeout 1s /opt/hashlink/hl run.hl > raw_out 2> raw_err';
+			case CPPIA(_):
+				docker += ' && timeout 1s /opt/cppia/Cppia run.cppia > raw_out 2> raw_err';
 		}
 		docker += "\"";
 
@@ -666,7 +678,7 @@ class Compiler {
 
 		switch (program.target) {
 			case JS(_):
-			case NEKO(_) | HL(_):
+			case NEKO(_) | HL(_) | CPPIA(_):
 				out += raw_out;
 			case EVAL(_):
 				out += haxe_out;

--- a/src/api/Program.hx
+++ b/src/api/Program.hx
@@ -41,6 +41,7 @@ enum TargetV2 {
 	NEKO(name:String);
 	EVAL(name:String);
 	HL(name:String);
+	CPPIA(name:String);
 }
 
 enum ECMAScriptVersion {

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -11,6 +11,7 @@ abstract Target(String) from String to String {
 	var Js = "js";
 	var Neko = "neko";
 	var Cpp = "cpp";
+	var Cppia = "cppia";
 	var Cs = "cs";
 	var Java = "java";
 	var Python = "python";

--- a/www/index.html
+++ b/www/index.html
@@ -206,6 +206,7 @@ class Macro {
                       <label class="radio-inline"><input type="radio" name="target" value="NEKO"></input> Neko</label>
                       <label class="radio-inline"><input type="radio" name="target" value="EVAL"></input> Eval</label>
                       <label class="radio-inline"><input type="radio" name="target" value="HL"></input> HashLink</label>
+                      <label class="radio-inline"><input type="radio" name="target" value="CPPIA"></input> Cppia</label>
                     </div>
 
                   </div>
@@ -246,6 +247,7 @@ class Macro {
                     <div class="controls col-sm-4 NEKO-libs"></div>
                     <div class="controls col-sm-4 EVAL-libs"></div>
                     <div class="controls col-sm-4 HL-libs"></div>
+                    <div class="controls col-sm-4 CPPIA-libs"></div>
 
                   </div>
               </form>


### PR DESCRIPTION
This allows building and running cppia scripts using the default cppia host provided by hxcpp.